### PR TITLE
Add check & install for cmlapi

### DIFF
--- a/code/0_bootstrap.py
+++ b/code/0_bootstrap.py
@@ -50,7 +50,14 @@ import os
 import json
 import requests
 
-import cmlapi
+# Install cmlapi package
+try:
+    import cmlapi
+except ModuleNotFoundError:
+    import os
+    cluster = os.getenv("CDSW_API_URL")[:-1]+"2"
+    !pip3 install {cluster}/python.tar.gz
+    import cmlapi 
 from cmlapi.rest import ApiException
 
 


### PR DESCRIPTION
While it's usually included in most CML/CDSW instances, in rare cases it is not. Adding this check (identical to that in the [CML_AMP_APIv2](https://github.com/cloudera/CML_AMP_APIv2/blob/master/CMLAPI.ipynb)) will catch this. 

Tested the code snippet under the except clause in both CML and CDSW