### PR TITLE
DSE-31986: Canceled Flight Prediction AMP deployment fails due to package import issue. [ not a workload region testing blocker]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ xgboost==1.6.1
 numpy==1.19.4
 flask==2.2.1
 seaborn==0.11.2
+Werkzeug==2.2.2


### PR DESCRIPTION
Werkzeug 3.0.0 version is not compatible with FLask 2.2.2.
Pinned the Werkzeug version to 2.2.2 and tested it on mow-dev.