### PR TITLE
Reduced model name length

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -99,7 +99,7 @@ tasks:
       Running the job to train models.
 
   - type: create_model
-    name: Flight Delay Prediction Model Endpoint
+    name: Flight Delay Prediction Model
     entity_label: flight_model
     description: This model api endpoint predicts flight delays
     short_summary: Create the flight delay prediction model api endpoint
@@ -109,7 +109,7 @@ tasks:
       num_replicas: 1
 
   - type: build_model
-    name: Flight Delay Prediction Model API Endpoint
+    name: Flight Delay Prediction Model
     entity_label: flight_model
     comment: Build flight prediction model
     examples:


### PR DESCRIPTION
 ## Summary

Recently, we implemented workload versioning as part of the AMP restart feature. As a result, the PVC name now exceeds 63 characters, prompting us to shorten the model name to ensure it fits within the limits

```2024-03-22 21:34:23.383	11	WARNING	DS.Operator.ModelDeployments  	Cleaning up model deployment due to setup failure	data = {"deployment":"flight-delay-prediction-model-endpoint-v1-1-3-7"}
2024-03-22 21:34:23.384	11	ERROR  	DS.Operator.ModelDeployments  	Failed to delete model deployment	data = {"err":"deployments.apps \"flight-delay-prediction-model-endpoint-v1-1-3-7\" not found"}
2024-03-22 21:34:23.384	11	ERROR  	DS.Operator.Server            	o4gg8lo9khyvnvho              	Finish StartModelDeployment, failed	data = {"err":"Deployment.apps \"flight-delay-prediction-model-endpoint-v1-1-3-7\" is invalid: [spec.template.spec.volumes[13].name: Invalid value: \"flight-delay-prediction-model-endpoint-v1-1-3-7-fluent-bit-config\": must be no more than 63 characters, spec.template.spec.containers[4].volumeMounts[0].name: Not found: \"flight-delay-prediction-model-endpoint-v1-1-3-7-fluent-bit-config\"]"}
2024-03-22 21:34:23.384	11	ERROR  	GRPC.Server                   	handler error	data = {"err":"Deployment.apps \"flight-delay-prediction-model-endpoint-v1-1-3-7\" is invalid: [spec.template.spec.volumes[13].name: Invalid value: \"flight-delay-prediction-model-endpoint-v1-1-3-7-fluent-bit-config\": must be no more than 63 characters, spec.template.spec.containers[4].volumeMounts[0].name: Not found: \"flight-delay-prediction-model-endpoint-v1-1-3-7-fluent-bit-config\"]"}```