### PR TITLE
DSE-49695: Ignore SQLite journal files under .explore to prevent S2I commit issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ spark-warehouse
 .explore/django_cache
 .explore/arcviz.log
 .explore/media
+.explore/*.db-*


### PR DESCRIPTION
## Problem
`usage.db-journal` is a SQLite file created during DB transactions and appears to be removed during the S2I Git commit, causing inconsistent AMP behavior.

## Fix
Ignore SQLite journal files under `.explore` by adding:


## Testing
verified by deploying the AMP with the changes from the PR
<img width="1293" height="299" alt="Screenshot 2026-01-06 at 11 13 32 AM" src="https://github.com/user-attachments/assets/804ffa3c-2ad3-4de9-aa9d-5a7f1a13f9c1" />
