### PR TITLE
chore: update repo to use python 3.13 runtime

### DIFF
--- a/.project-metadata.yaml
+++ b/.project-metadata.yaml
@@ -41,9 +41,9 @@ feature_dependencies:
 
 runtimes:
   - editor: PBJ Workbench
-    kernel: Python 3.9
+    kernel: Python 3.13
     edition: Standard
-    addons: ["Spark 3.2.3 - CDE 1.22.0"]
+    addons: ["Spark 3.2.3 - CDE 1.24.1 - HOTFIX-1"]
 
 
 tasks:

--- a/code/7_application.py
+++ b/code/7_application.py
@@ -40,7 +40,6 @@
 
 from flask import Flask, send_from_directory, request
 import logging
-from pandas.io.json import dumps as jsonify
 import os
 import random
 from IPython.display import Javascript, HTML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-pandas==1.3.5
-joblib==1.1.0
-scikit-learn==1.0.2
-xgboost==1.6.1
-numpy==1.19.4
-flask==2.2.1
-seaborn==0.11.2
-Werkzeug==2.2.2
+numpy>=2.1.0
+pandas>=2.2.3
+scikit-learn>=1.5.0
+xgboost>=2.1.0
+joblib>=1.2.0
+flask>=2.2.0
+seaborn>=0.13.0
+Werkzeug>=2.2.0


### PR DESCRIPTION
update amp to use python 3.13 runtime